### PR TITLE
Added github citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,6 @@
+@inproceedings{DataAnalytics2022,
+  author  = { Jakovljevic, I., Pobaschnig, M., Gütl, C. AND Wagner, A. },
+  year    = { 2022 },
+  month   = { 11 },
+  title   = { Privacy Aware Identification of User Clusters in Large Organisations based on Anonymized Mattermost User and Channel Information }
+}


### PR DESCRIPTION
Added `.cff` file which enables a quick action button in the repository for citation and also adds metadata information.

[Github Citation Files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)